### PR TITLE
Example: add example running sim and reco for CLIC

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
     setup-and-getting-started/README.md
     spack-build-instructions/README.md
     spack-build-instructions/spack-advanced.md
+    examples/clic.md
     talks-and-presentations/README.md
     call-for-logos/README.md
     CONTRIBUTING.md

--- a/examples/clic.md
+++ b/examples/clic.md
@@ -49,8 +49,15 @@ Now we need to modify the ``clicReconstruction.py`` file to point to the ``ttbar
 Config.OverlayFalse`` and ``# Config.TrackingConformal`` should be enabled by uncommenting their line in the ``algList``
 at the end of the file.
 
-```
-sed ...
+```bash
+sed -i 's;read.Files = \["/run/simulation/with/ctest/to/create/a/file.slcio"\];read.Files = \["ttbar.slcio"\];' clicReconstruction.py
+sed -i 's;EvtMax   = 10,;EvtMax   = 3,;' clicReconstruction.py
+sed -i 's;"MaxRecordNumber", "10", END_TAG,;"MaxRecordNumber", "3", END_TAG,;' clicReconstruction.py
+sed -i 's;# algList.append(OverlayFalse);algList.append(OverlayFalse);' clicReconstruction.py
+sed -i 's;# algList.append(MyConformalTracking);algList.append(MyConformalTracking);' clicReconstruction.py
+sed -i 's;# algList.append(ClonesAndSplitTracksFinder);algList.append(ClonesAndSplitTracksFinder);' clicReconstruction.py
+sed -i 's;# algList.append(RenameCollection);algList.append(RenameCollection);' clicReconstruction.py
+sed -i 's;"DD4hepXMLFile", "/cvmfs/clicdp.cern.ch/iLCSoft/builds/nightly/x86_64-slc6-gcc62-opt/lcgeo/HEAD/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml",; "DD4hepXMLFile", "/cvmfs/sw.hsf.org/spackages/linux-centos7-broadwell/gcc-8.3.0/lcgeo-0.16.6-n2cn5dmwe4zttcgltxamnbfzq26kofie/share/lcgeo/compact/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml",;' clicReconstruction.py
 
 ```
 

--- a/examples/clic.md
+++ b/examples/clic.md
@@ -62,7 +62,7 @@ sed -i 's;# algList.append(OverlayFalse);algList.append(OverlayFalse);' clicReco
 sed -i 's;# algList.append(MyConformalTracking);algList.append(MyConformalTracking);' clicReconstruction.py
 sed -i 's;# algList.append(ClonesAndSplitTracksFinder);algList.append(ClonesAndSplitTracksFinder);' clicReconstruction.py
 sed -i 's;# algList.append(RenameCollection);algList.append(RenameCollection);' clicReconstruction.py
-sed -i 's;"DD4hepXMLFile", "/cvmfs/clicdp.cern.ch/iLCSoft/builds/nightly/x86_64-slc6-gcc62-opt/lcgeo/HEAD/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml",; "DD4hepXMLFile", "/cvmfs/sw.hsf.org/spackages/linux-centos7-broadwell/gcc-8.3.0/lcgeo-0.16.6-n2cn5dmwe4zttcgltxamnbfzq26kofie/share/lcgeo/compact/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml",;' clicReconstruction.py
+sed -i 's;"DD4hepXMLFile", ".*",; "DD4hepXMLFile", "os.environ["LCGEO"]+"/compact/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml",;' clicReconstruction.py
 
 ```
 

--- a/examples/clic.md
+++ b/examples/clic.md
@@ -43,9 +43,16 @@ We can convert the ``xml`` steering file to a Gaudi steering file
 ```bash
 convertMarlinSteeringToGaudi.py clicReconstruction.xml  > clicReconstruction.py
 ```
+
 Now we need to modify the ``clicReconstruction.py`` file to point to the ``ttbar.slcio`` input file, and change the
-``DD4hepXMLFile`` parameter for the ``InitDD4hep`` algorithm, and enable a few of the optional processors in the
-``algList`` at the end of the file.
+``DD4hepXMLFile`` parameter for the ``InitDD4hep`` algorithm.  In addition the two processors with the comment ``#
+Config.OverlayFalse`` and ``# Config.TrackingConformal`` should be enabled by uncommenting their line in the ``algList``
+at the end of the file.
+
+```
+sed ...
+
+```
 
 Then the reconstruction using the wrapper can be run with
 

--- a/examples/clic.md
+++ b/examples/clic.md
@@ -2,6 +2,11 @@
 
 
 This assumes that you have access to an installation of the Key4hep-stack, either via ``CVMFS`` or ``spack install``.
+To setup the installation on cvmfs, do:
+
+```bash
+source /cvmfs/sw.hsf.org/key4hep/setup.sh
+```
 
 These commands will explain how one can run the CLIC detector simulation and reconstruction using the Key4hep-Stack.
 First we will obtain all the necessary steering and input files for CLIC, simulate a few events and run the

--- a/examples/clic.md
+++ b/examples/clic.md
@@ -55,7 +55,7 @@ Config.OverlayFalse`` and ``# Config.TrackingConformal`` should be enabled by un
 at the end of the file.
 
 ```bash
-sed -i 's;read.Files = \["/run/simulation/with/ctest/to/create/a/file.slcio"\];read.Files = \["ttbar.slcio"\];' clicReconstruction.py
+sed -i 's;read.Files = \[".*"\];read.Files = \["ttbar.slcio"\];' clicReconstruction.py
 sed -i 's;EvtMax   = 10,;EvtMax   = 3,;' clicReconstruction.py
 sed -i 's;"MaxRecordNumber", "10", END_TAG,;"MaxRecordNumber", "3", END_TAG,;' clicReconstruction.py
 sed -i 's;# algList.append(OverlayFalse);algList.append(OverlayFalse);' clicReconstruction.py

--- a/examples/clic.md
+++ b/examples/clic.md
@@ -1,0 +1,54 @@
+# Using the Key4hep-Stack for CLIC Simulation and Reconstruction
+
+
+This assumes that you have access to an installation of the Key4hep-stack, either via ``CVMFS`` or ``spack install``.
+
+These commands will explain how one can run the CLIC detector simulation and reconstruction using the Key4hep-Stack.
+First we will obtain all the necessary steering and input files for CLIC, simulate a few events and run the
+reconstruction both with ``Marlin`` and ``k4run``. These steps can be adapted to simulate or run other ``Marlin``
+processors as well.
+
+The ``CLICPerformance`` repository contains the steering and input files.
+```bash
+git clone https://github.com/iLCSoft/CLICPerformance
+cd CLICPerformance/clicConfig
+```
+
+## Simulation
+
+Now we can already simulate a few events
+```bash
+ddsim --compactFile $LCGEO/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml \
+      --outputFile ttbar.slcio \
+      --steeringFile clic_steer.py \
+      --inputFiles ../Tests/yyxyev_000.stdhep \
+      --numberOfEvents 3
+```
+
+## Reconstruction
+
+### Reconstruction with Marlin
+
+To run the reconstruction with ``Marlin``
+```bash
+Marlin clicReconstruction.xml \
+       --InitDD4hep.DD4hepXMLFile=$LCGEO/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14 \
+       --global.LCIOInputFiles=ttbar.slcio \
+       --global.MaxRecordNumber=3
+```
+
+### Reconstruction with with Gaudi
+
+We can convert the ``xml`` steering file to a Gaudi steering file
+```bash
+convertMarlinSteeringToGaudi.py clicReconstruction.xml  > clicReconstruction.py
+```
+Now we need to modify the ``clicReconstruction.py`` file to point to the ``ttbar.slcio`` input file, and change the
+``DD4hepXMLFile`` parameter for the ``InitDD4hep`` algorithm, and enable a few of the optional processors in the
+``algList`` at the end of the file.
+
+Then the reconstruction using the wrapper can be run with
+
+```
+k4run clicReconstruction.py
+```

--- a/examples/clic.md
+++ b/examples/clic.md
@@ -32,7 +32,7 @@ ddsim --compactFile $LCGEO/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml \
 To run the reconstruction with ``Marlin``
 ```bash
 Marlin clicReconstruction.xml \
-       --InitDD4hep.DD4hepXMLFile=$LCGEO/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14 \
+       --InitDD4hep.DD4hepXMLFile=$LCGEO/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml \
        --global.LCIOInputFiles=ttbar.slcio \
        --global.MaxRecordNumber=3
 ```


### PR DESCRIPTION
This adds text on how to run simulation and reconstruction for CLIC, at the moment the k4run instructions still require the manual modification of the steering file. What would be the best way to add command line arguments for this?