### PR TITLE
ClicExample: fix sed replacing for detmodel

### DIFF
--- a/examples/clic.md
+++ b/examples/clic.md
@@ -62,7 +62,7 @@ sed -i 's;# algList.append(OverlayFalse);algList.append(OverlayFalse);' clicReco
 sed -i 's;# algList.append(MyConformalTracking);algList.append(MyConformalTracking);' clicReconstruction.py
 sed -i 's;# algList.append(ClonesAndSplitTracksFinder);algList.append(ClonesAndSplitTracksFinder);' clicReconstruction.py
 sed -i 's;# algList.append(RenameCollection);algList.append(RenameCollection);' clicReconstruction.py
-sed -i 's;"DD4hepXMLFile", ".*",; "DD4hepXMLFile", "os.environ["LCGEO"]+"/compact/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml",;' clicReconstruction.py
+sed -i 's;"DD4hepXMLFile", ".*",; "DD4hepXMLFile", os.environ["LCGEO"]+"/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml",;' clicReconstruction.py
 
 ```
 


### PR DESCRIPTION
* `$LCGEO` points to to share/compact.
* syntax error with too many `"`