### PR TITLE
[clicexample] update paths

### DIFF
--- a/examples/clic.md
+++ b/examples/clic.md
@@ -4,7 +4,7 @@
 This assumes that you have access to an installation of the Key4hep-stack, either via ``CVMFS`` or ``spack install``.
 To setup the installation on cvmfs, do:
 
-```bash
+```
 source /cvmfs/sw.hsf.org/key4hep/setup.sh
 ```
 
@@ -14,13 +14,15 @@ reconstruction both with ``Marlin`` and ``k4run``. These steps can be adapted to
 processors as well.
 
 The ``CLICPerformance`` repository contains the steering and input files.
+
 ```bash
 git clone https://github.com/iLCSoft/CLICPerformance
 ```
 
 ## Simulation
 
-Now we can already simulate a few events
+Now we can already simulate a few events:
+
 ```bash
 cd CLICPerformance/clicConfig
 
@@ -35,7 +37,8 @@ ddsim --compactFile $LCGEO/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml \
 
 ### Reconstruction with Marlin
 
-To run the reconstruction with ``Marlin``
+To run the reconstruction with ``Marlin``:
+
 ```bash
 cd CLICPerformance/clicConfig
 
@@ -48,6 +51,7 @@ Marlin clicReconstruction.xml \
 ### Reconstruction with with Gaudi
 
 We can convert the ``xml`` steering file to a Gaudi steering file
+
 ```bash
 cd CLICPerformance/clicConfig
 
@@ -75,7 +79,7 @@ sed -i 's;"DD4hepXMLFile", ".*",; "DD4hepXMLFile", os.environ["LCGEO"]+"/CLIC/co
 
 Then the reconstruction using the wrapper can be run with
 
-```
+```bash
 cd CLICPerformance/clicConfig
 
 k4run clicReconstruction.py

--- a/examples/clic.md
+++ b/examples/clic.md
@@ -16,13 +16,14 @@ processors as well.
 The ``CLICPerformance`` repository contains the steering and input files.
 ```bash
 git clone https://github.com/iLCSoft/CLICPerformance
-cd CLICPerformance/clicConfig
 ```
 
 ## Simulation
 
 Now we can already simulate a few events
 ```bash
+cd CLICPerformance/clicConfig
+
 ddsim --compactFile $LCGEO/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml \
       --outputFile ttbar.slcio \
       --steeringFile clic_steer.py \
@@ -36,6 +37,8 @@ ddsim --compactFile $LCGEO/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml \
 
 To run the reconstruction with ``Marlin``
 ```bash
+cd CLICPerformance/clicConfig
+
 Marlin clicReconstruction.xml \
        --InitDD4hep.DD4hepXMLFile=$LCGEO/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml \
        --global.LCIOInputFiles=ttbar.slcio \
@@ -46,6 +49,8 @@ Marlin clicReconstruction.xml \
 
 We can convert the ``xml`` steering file to a Gaudi steering file
 ```bash
+cd CLICPerformance/clicConfig
+
 convertMarlinSteeringToGaudi.py clicReconstruction.xml clicReconstruction.py
 ```
 
@@ -55,6 +60,8 @@ Config.OverlayFalse`` and ``# Config.TrackingConformal`` should be enabled by un
 at the end of the file.
 
 ```bash
+cd CLICPerformance/clicConfig
+
 sed -i 's;read.Files = \[".*"\];read.Files = \["ttbar.slcio"\];' clicReconstruction.py
 sed -i 's;EvtMax   = 10,;EvtMax   = 3,;' clicReconstruction.py
 sed -i 's;"MaxRecordNumber", "10", END_TAG,;"MaxRecordNumber", "3", END_TAG,;' clicReconstruction.py
@@ -69,5 +76,7 @@ sed -i 's;"DD4hepXMLFile", ".*",; "DD4hepXMLFile", os.environ["LCGEO"]+"/CLIC/co
 Then the reconstruction using the wrapper can be run with
 
 ```
+cd CLICPerformance/clicConfig
+
 k4run clicReconstruction.py
 ```


### PR DESCRIPTION
Each of the bash codecells runs in a new shell when executing as a notebook, so the directory changes need to be repeated in each cell. Not sure if there is a more elegant way, but since this can be used for both automatic checks and  to create notebooks to be run on SWAN I think this is worth it.

BEGINRELEASENOTES
- fix paths in examples/clic.md to make it run as notebook

ENDRELEASENOTES
