### PR TITLE
Update docs to use agreed upon naming scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Key4HEP 
+# Key4hep
 
 
 ```eval_rst

--- a/conf.py
+++ b/conf.py
@@ -2,9 +2,9 @@
 # Here it is useful to allow the configuration to be maintained elsewhere
 from starterkit_ci.sphinx_config import *  # NOQA
 
-project = 'Key4HEP'
-copyright = '2020, Key4HEP'
-author = 'Key4HEP'
+project = 'Key4hep'
+copyright = '2020, Key4hep'
+author = 'Key4hep'
 html_logo = 'starterkit.png'
 
 exclude_patterns += [

--- a/setup-and-getting-started/README.md
+++ b/setup-and-getting-started/README.md
@@ -1,8 +1,8 @@
 
 
-# Getting started with Key4HEP software
+# Getting started with Key4hep software
 
-## Setting up the Key4HEP Software Stack
+## Setting up the Key4hep Software Stack
 
 ### Using central installations on cvmfs
 
@@ -21,9 +21,9 @@ The instructions above should work in any CentOS7 virtual machine or Docker cont
 
 #### CernVM Virtual Appliance
 
-The CernVM project provides a convenient tool to start VMs, [cernvm-launch](https://cernvm.cern.ch/portal/launch), and a [public repository](https://github.com/cernvm/public-contexts) of contexts to be used with `cernvm-launch` to configure the VM at your needs. A context dedicated to Key4HEP is available in the repository. The [cernvm-launch](https://cernvm.cern.ch/portal/launch) works with [VirtualBox](https://www.virtualbox.org/), virtualization manager available for free for all platforms.
+The CernVM project provides a convenient tool to start VMs, [cernvm-launch](https://cernvm.cern.ch/portal/launch), and a [public repository](https://github.com/cernvm/public-contexts) of contexts to be used with `cernvm-launch` to configure the VM at your needs. A context dedicated to Key4hep is available in the repository. The [cernvm-launch](https://cernvm.cern.ch/portal/launch) works with [VirtualBox](https://www.virtualbox.org/), virtualization manager available for free for all platforms.
 
-To create and use a CernVM virtual machine for Key4HEP please follow the following steps:
+To create and use a CernVM virtual machine for Key4hep please follow the following steps:
 
    * Make sure [VirtualBox](https://www.virtualbox.org/) is installed (details installing instructions from the product web page).
    * Download the `cernvm-launch` binary for your platform either from the [dedicated download page](https://ecsft.cern.ch/dist/cernvm/launch/bin/) or from the following links:

--- a/spack-build-instructions/README.md
+++ b/spack-build-instructions/README.md
@@ -1,9 +1,9 @@
-# Using Spack to build Key4HEP software
+# Using Spack to build Key4hep software
 
-Key4HEP comprises a fairly large number of software and depends on even more externals, so some tooling is needed to efficiently build the whole software stack. The [spack](https://spack.io) package manager can be used to build scientific software at scale, and is part of the Key4HEP software R&D program.
+Key4hep comprises a fairly large number of software and depends on even more externals, so some tooling is needed to efficiently build the whole software stack. The [spack](https://spack.io) package manager can be used to build scientific software at scale, and is part of the Key4hep software R&D program.
 
 
-A spack install of Key4HEP is regularly deployed to `/cvmfs/sw.hsf.org/`, and can be used on lxplus/centos7 just by sourcing the following setup script:
+A spack install of Key4hep is regularly deployed to `/cvmfs/sw.hsf.org/`, and can be used on lxplus/centos7 just by sourcing the following setup script:
 
 ```bash
 source /cvmfs/sw.hsf.org/key4hep/setup.sh

--- a/spack-build-instructions/spack-buildcache.md
+++ b/spack-build-instructions/spack-buildcache.md
@@ -3,7 +3,7 @@
 
 {% callout "Spack documentation" %}
 
-Buildcaches were investigated, but are no longer supported for Key4HEP software, due to the difficulty of relocating some packages.
+Buildcaches were investigated, but are no longer supported for Key4hep software, due to the difficulty of relocating some packages.
 
 For more information refer to the [spack documentation](https://spack.readthedocs.io/en/latest/binary_caches.html).
 

--- a/spack-build-instructions/spack-developer-workflows.md
+++ b/spack-build-instructions/spack-developer-workflows.md
@@ -1,9 +1,9 @@
-# Spack workflows for developing Key4HEP software
+# Spack workflows for developing Key4hep software
 
 Using spack to develop software is somewhat pushing its intended usage to its limits.
 However, it is not impossible and this is an area of spack that is currently under active development.
 Unfortunately, this also means that the spack documentation might not be fully up-to-date on these topics.
-Hence, this page tries to collect some of the experiences the Key4HEP developers have made.
+Hence, this page tries to collect some of the experiences the Key4hep developers have made.
 
 ## Developing a single package
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Replace all appearances of "Key4HEP" with "Key4hep". Leave only the talk titles of past presentations untouched.

ENDRELEASENOTES
