### PR TITLE
Add build workflow, make it check for deadlinks and add auto fetching of external docs

### DIFF
--- a/.github/scripts/fetch_external_sources.sh
+++ b/.github/scripts/fetch_external_sources.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Script that tries to automatically fetch further documentation from other
+# github repositories, where it simply assumes that they are available under the
+# same name. Runs through our ususal suspects of github organizations while
+# trying to do so
+
+# Try to fetch a file from a github repository
+try_fetch() {
+    local org=${1}
+    local file=${2}
+    local repo=$(echo ${file} | awk -F '/' '{print $1}')
+    local repo_file=${file/${repo}/}
+
+    curl --fail --silent https://raw.githubusercontent.com/${org}/${repo}/master/${repo_file#/} -o ${file}
+}
+
+while read -r line; do
+  # Check if line is non-empty and ends on .md
+  if [ -n "${line}" ] && [[ "${line}" == *.md ]]; then
+    # If the file exists do nothing, otherwise pull it in from github
+    if ! ls "${line}" > /dev/null 2>&1; then
+      echo "${line} does not exist. Trying to fetch it from github"
+      mkdir -p  $(dirname ${line}) # make the directory for the output
+
+      # Try a few github organizations
+      for org in key4hep HEP-FCC AIDASoft iLCSoft; do
+        echo "Trying to fetch from github organization: '${org}'"
+        if try_fetch ${org} ${line}; then
+          echo "Fetched succesfully from organization '${org}'"
+          break
+        fi
+      done
+    fi
+
+    # Check again if we hav succesfully fetched the file
+    if ! ls "${line}" > /dev/null 2>&1; then
+      echo "Could not fetch file '${line}' from external sources" 1>&2
+      exit 1
+    fi
+  fi
+done < README.md

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,24 @@
+name: build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Install Requirements
+      run: |
+        pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Fetch external sources
+      run: |
+        bash .github/scripts/fetch_external_sources.sh
+    - name: Sphinx build
+      run: |
+        sphinx-build -M html . build -b linkcheck

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,15 +17,18 @@ jobs:
       fail-fast: false
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
     - name: Install Requirements
       run: |
-        pip3 install -r requirements.txt
+        pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Fetch external sources
+      run: |
+        bash .github/scripts/fetch_external_sources.sh
     - name: Sphinx build
       run: |
-        # pull in pages from other repositories
-        mkdir -p k4marlinwrapper/doc/starterkit/k4MarlinWrapperCLIC/
-        curl --fail --silent https://raw.githubusercontent.com/key4hep/k4MarlinWrapper/master/doc/starterkit/k4MarlinWrapperCLIC/Readme.md -o k4marlinwrapper/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
-        # build site
         sphinx-build -M html . build
     - name: Publish gh-pages
       if: ${{ github.ref == 'refs/heads/master' }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ You also agree to abide by our [contributor code of conduct][conduct].
 1.  We use the [fork and pull][gh-fork-pull] model to manage changes.
     More information about [forking a repository][gh-fork] and [making a Pull Request][gh-pull].
 
-2.  To build the lessons please install the [dependencies](#DEPENDENCIES).
+2.  To build the lessons please install the [dependencies](#dependencies).
 
 2.  For our lessons, you should branch from and submit pull requests against the `master` branch.
 

--- a/conf.py
+++ b/conf.py
@@ -23,7 +23,7 @@ html_context = {
 extensions = [
     'sphinx_copybutton',
     'sphinx_markdown_tables',
-    'recommonmark',
+    'myst_parser',
 ]
 
 source_suffix = {
@@ -37,4 +37,4 @@ html_static_path += [
 linkcheck_ignore += [
 ]
 
-
+myst_heading_anchors = 3

--- a/developing-key4hep-software/Key4hepCMakeGuide.md
+++ b/developing-key4hep-software/Key4hepCMakeGuide.md
@@ -124,7 +124,7 @@ CMAKEFLAGS='--trace' make
 
 Instead of running `  make` , run:
 
- ```{.bash}
+ ```bash
  make VERBOSE=1 
  ```
 

--- a/developing-key4hep-software/Key4hepSoftwareGit.md
+++ b/developing-key4hep-software/Key4hepSoftwareGit.md
@@ -102,7 +102,7 @@ Please always follow the recommendations below.
 
 -   feel free to commit often to your local repository, make a pull request once the topic you are working on is finished
     - if the feature you are working on is large, consider making a work in progress-pull request (see [below](#pull-requests))
-    - git commits represent a snapshot of the software as a whole, and not only the difference to a previous commit (although that as well, in practice). It is recommended that each commit compiles and passes the tests. Take a look at the [commit history of a key4hep repository](https://github.com/key4hep/k4simdelphes/commits/master) and the histories of some individual files to find both good and bad examples. 
+    - git commits represent a snapshot of the software as a whole, and not only the difference to a previous commit (although that as well, in practice). It is recommended that each commit compiles and passes the tests. Take a look at the [commit history of a key4hep repository](https://github.com/key4hep/k4simdelphes/commits/main) and the histories of some individual files to find both good and bad examples.
     
 -   always provide a meaningful comment for each commit
     -   if you are working on an issue, refer to that issue by adding "refs. #[issue id]", see also

--- a/developing-key4hep-software/SpackForDevelopers.md
+++ b/developing-key4hep-software/SpackForDevelopers.md
@@ -63,14 +63,12 @@ However, it is of course encouraged to use a meaningful version specifier, since
 ### Using the local version as dependency
 
 Now that the local version has been installed, it would of course be nice to be able to use it in downstream packages as well.
-Spack doesn't pick package versions installed from local sources by default, but as with any other package it is possible to require a specific version of a dependency.
-This is described in a bit more detail [here](https://key4hep.github.io/key4hep-doc/spack-build-instructions/spack-advanced.html#concretizing-before-installation).
-
-Let's first find out how the version that we have just installed looks like
+As far as spack is concerned, a package that has been built from local sources is not really different from one that has been built from automatically downloaded sources.
+The main difference is that the fact that it has been built from local sources manifests in the spec
 ```bash
 spack find -lv lcio
 ```
-which will yield something similar to
+will yield something like
 ```
 ==> 1 installed package
 -- linux-ubuntu20.04-skylake / gcc@9.3.0 ------------------------
@@ -78,6 +76,12 @@ which will yield something similar to
 ```
 As you can see the local path from which this version was installed has become part of the spec for the installed package (the `dev_path=...` part of the spec above).
 Hence, also the hash is affected by the fact that it has been built from a local source.
+
+To use this specific version as a dependency the usual spack syntax can be used, e.g.
+```bash
+spack install marlin ^lcio/7dovpqn
+```
+will install `marlin` but use the version of `lcio` that we have just built locally.
 
 ### More advanced usage
 Note: If you have installed lcio following the description above you might have to uninstall it again first to follow these instructions, because spack will not overwrite an already installed package.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/chrisburr/recommonmark.git@patch-1
+myst-parser==0.17.0
 starterkit-ci==0.0.12
 sphinx-copybutton==0.3.0
 sphinx-markdown-tables==0.0.15


### PR DESCRIPTION
BEGINRELEASENOTES
- Add a build workflow that builds the documentation and checks that all links are valid
  - Fix a few broken links
- Automatically try to fetch markdown files referenced in the toplevel toc (README.md) file from external github repositories
- Switch from `recommonmark` to `myst_parser` for parsing markdown file, since the former has been deprecated: readthedocs/recommonmark#221

ENDRELEASENOTES

Fixes #29 
Makes #13 samewhat easier to do as adding an external file should be enough to pull it in

The fetching of additional files from external github repositories works by first checking if the file exists in the checked out repository. If that is not the case, then it will look in the `key4hep`, `HEP-FCC`, `AIDASoft` and `iLCSoft` github organisations for the file (in this order). It will use the first part of the name as repository and the rest as path inside the repository. E.g.
```
k4marlinwrapper/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
```
will look for a `k4marlinwrapper` repository in the above organisations and if it finds one it will look for a file `doc/starterkit/k4MarlinWrapperCLIC/Readme.md` in that repository. If it finds it, it will download it to the original path locally and make it available to the sphinx build process. Only the first match of this file will be downloaded.

This should make it possible to simply add external docs here, and have them appear in the central documentation.