### PR TITLE
Add k4simdelphes documentation

### DIFF
--- a/.github/scripts/fetch_external_sources.sh
+++ b/.github/scripts/fetch_external_sources.sh
@@ -11,7 +11,9 @@ try_fetch() {
     local repo=$(echo ${file} | awk -F '/' '{print $1}')
     local repo_file=${file/${repo}/}
 
-    curl --fail --silent https://raw.githubusercontent.com/${org}/${repo}/master/${repo_file#/} -o ${file}
+    for branch in main master; do
+      curl --fail --silent https://raw.githubusercontent.com/${org}/${repo}/${branch}/${repo_file#/} -o ${file} && break
+    done
 }
 
 while read -r line; do

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ build
 
 # external repositories
 k4marlinwrapper/
+k4simdelphes/

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 
     setup-and-getting-started/README.md
     k4marlinwrapper/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
+    k4simdelphes/doc/starterkit/k4SimDelphes/Readme.md
     developing-key4hep-software/README.md
     spack-build-instructions-for-librarians/README.md
     talks-and-presentations/README.md


### PR DESCRIPTION
BEGINRELEASENOTES
- Add a bit of documentation for k4SimDelphes (standalone running only at the moment)
- Make the fetch script also work with `main` as default branch

ENDRELEASENOTES

- [x] Needs key4hep/k4SimDelphes#71