### PR TITLE
link to k4marlinwrapper extra doc files

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
     setup-and-getting-started/README.md
     k4marlinwrapper/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
+    k4marlinwrapper/doc/starterkit/k4MarlinWrapperCLIC/edmConverters.md
+    k4marlinwrapper/doc/starterkit/k4MarlinWrapperCLIC/howtoMultithread.md
     k4simdelphes/doc/starterkit/k4SimDelphes/Readme.md
     developing-key4hep-software/README.md
     spack-build-instructions-for-librarians/README.md


### PR DESCRIPTION
BEGINRELEASENOTES
- Adds documentation files on EDM converters and How to do multithreading with Gaudi

ENDRELEASENOTES


Needs https://github.com/key4hep/k4MarlinWrapper/pull/84