### PR TITLE
Add the Event Display documentation to the main page

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
     k4marlinwrapper/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
     k4marlinwrapper/doc/starterkit/k4MarlinWrapperCLIC/edmConverters.md
     k4marlinwrapper/doc/starterkit/k4MarlinWrapperCLIC/howtoMultithread.md
+    k4marlinwrapper/doc/starterkit/k4MarlinWrapperCLIC/CEDViaWrapper.md
     k4simdelphes/doc/starterkit/k4SimDelphes/Readme.md
     developing-key4hep-software/README.md
     spack-build-instructions-for-librarians/README.md


### PR DESCRIPTION
BEGINRELEASENOTES
- Add the k4MarlinWrapper event display documentation to the main page

ENDRELEASENOTES

Needs key4hep/k4MarlinWrapper#87