### PR TITLE
Add a tutorial section to the page

### DIFF
--- a/.github/scripts/fetch_external_sources.sh
+++ b/.github/scripts/fetch_external_sources.sh
@@ -16,28 +16,36 @@ try_fetch() {
     done
 }
 
-while read -r line; do
-  # Check if line is non-empty and ends on .md
-  if [ -n "${line}" ] && [[ "${line}" == *.md ]]; then
-    # If the file exists do nothing, otherwise pull it in from github
-    if ! ls "${line}" > /dev/null 2>&1; then
-      echo "${line} does not exist. Trying to fetch it from github"
-      mkdir -p  $(dirname ${line}) # make the directory for the output
+# process one markdown file with content that potentially needs fetching from an
+# external repository
+fetch_for_file() {
+  local file_to_proc=${1}
 
-      # Try a few github organizations
-      for org in key4hep HEP-FCC AIDASoft iLCSoft; do
-        echo "Trying to fetch from github organization: '${org}'"
-        if try_fetch ${org} ${line}; then
-          echo "Fetched succesfully from organization '${org}'"
-          break
-        fi
-      done
-    fi
+  while read -r line; do
+    # Check if line is non-empty and ends on .md
+    if [ -n "${line}" ] && [[ "${line}" == *.md ]]; then
+      # If the file exists do nothing, otherwise pull it in from github
+      if ! ls "${line}" > /dev/null 2>&1; then
+        echo "${line} does not exist. Trying to fetch it from github"
+        mkdir -p  $(dirname ${line}) # make the directory for the output
 
-    # Check again if we hav succesfully fetched the file
-    if ! ls "${line}" > /dev/null 2>&1; then
-      echo "Could not fetch file '${line}' from external sources" 1>&2
-      exit 1
+        # Try a few github organizations
+        for org in key4hep HEP-FCC AIDASoft iLCSoft; do
+          echo "Trying to fetch from github organization: '${org}'"
+          if try_fetch ${org} ${line}; then
+            echo "Fetched succesfully from organization '${org}'"
+            break
+          fi
+        done
+      fi
+
+      # Check again if we hav succesfully fetched the file
+      if ! ls "${line}" > /dev/null 2>&1; then
+        echo "Could not fetch file '${line}' from external sources" 1>&2
+        exit 1
+      fi
     fi
-  fi
-done < README.md
+  done < ${file_to_proc}
+}
+
+fetch_for_file README.md

--- a/.github/scripts/fetch_external_sources.sh
+++ b/.github/scripts/fetch_external_sources.sh
@@ -8,11 +8,12 @@
 try_fetch() {
     local org=${1}
     local file=${2}
+    local outputbase=${3}
     local repo=$(echo ${file} | awk -F '/' '{print $1}')
     local repo_file=${file/${repo}/}
 
     for branch in main master; do
-      curl --fail --silent https://raw.githubusercontent.com/${org}/${repo}/${branch}/${repo_file#/} -o ${file} && break
+      curl --fail --silent https://raw.githubusercontent.com/${org}/${repo}/${branch}/${repo_file#/} -o ${outputbase}/${file} && break
     done
 }
 
@@ -20,19 +21,24 @@ try_fetch() {
 # external repository
 fetch_for_file() {
   local file_to_proc=${1}
+  local file_dir=$(dirname $(realpath ${file_to_proc}))
+
+  echo "Fetching external contents for file '${file_to_proc}'"
 
   while read -r line; do
     # Check if line is non-empty and ends on .md
     if [ -n "${line}" ] && [[ "${line}" == *.md ]]; then
       # If the file exists do nothing, otherwise pull it in from github
-      if ! ls "${line}" > /dev/null 2>&1; then
+      local file_to_fetch=${file_dir}/${line}
+      if ! ls "${file_to_fetch}" > /dev/null 2>&1; then
         echo "${line} does not exist. Trying to fetch it from github"
-        mkdir -p  $(dirname ${line}) # make the directory for the output
+        local outputdir=$(dirname ${file_to_fetch})
+        mkdir -p ${outputdir}  # make the directory for the output
 
         # Try a few github organizations
         for org in key4hep HEP-FCC AIDASoft iLCSoft; do
           echo "Trying to fetch from github organization: '${org}'"
-          if try_fetch ${org} ${line}; then
+          if try_fetch ${org} ${line} ${file_dir}; then
             echo "Fetched succesfully from organization '${org}'"
             break
           fi
@@ -40,7 +46,7 @@ fetch_for_file() {
       fi
 
       # Check again if we hav succesfully fetched the file
-      if ! ls "${line}" > /dev/null 2>&1; then
+      if ! ls "${file_to_fetch}" > /dev/null 2>&1; then
         echo "Could not fetch file '${line}' from external sources" 1>&2
         exit 1
       fi
@@ -49,3 +55,4 @@ fetch_for_file() {
 }
 
 fetch_for_file README.md
+fetch_for_file tutorials/README.md

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
     :caption: Contents:
 
     setup-and-getting-started/README.md
+    tutorials/README.md
     k4marlinwrapper/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
     k4marlinwrapper/doc/starterkit/k4MarlinWrapperCLIC/edmConverters.md
     k4marlinwrapper/doc/starterkit/k4MarlinWrapperCLIC/howtoMultithread.md

--- a/README.md
+++ b/README.md
@@ -9,11 +9,6 @@
 
     setup-and-getting-started/README.md
     tutorials/README.md
-    k4marlinwrapper/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
-    k4marlinwrapper/doc/starterkit/k4MarlinWrapperCLIC/edmConverters.md
-    k4marlinwrapper/doc/starterkit/k4MarlinWrapperCLIC/howtoMultithread.md
-    k4marlinwrapper/doc/starterkit/k4MarlinWrapperCLIC/CEDViaWrapper.md
-    k4simdelphes/doc/starterkit/k4SimDelphes/Readme.md
     developing-key4hep-software/README.md
     spack-build-instructions-for-librarians/README.md
     talks-and-presentations/README.md

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -1,0 +1,19 @@
+# Key4hep Tutorials
+
+This page contains several tutorials for working in a Key4hep software stack. We
+try to design and set them up in a way that they can be done at any time but we
+present them at hands-on tutorial sessions as well.
+
+**If you are following these tutorials and run into an issue please let us know
+by [opening an issue](https://github.com/key4hep/key4hep-doc/issues/new/choose)
+on the [`key4hep-doc`](https://github.com/key4hep/key4hep-doc) repository.** If
+you have the feeling that something is missing, we are also very happy to accept
+new tutorial suggestions. If you have a tutorial that you would like to add
+here.
+
+```eval_rst
+.. toctree::
+    :caption: Exercises
+
+    example.md
+```

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -15,5 +15,9 @@ here.
 .. toctree::
     :caption: Exercises
 
-    example.md
+    k4marlinwrapper/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
+    k4marlinwrapper/doc/starterkit/k4MarlinWrapperCLIC/edmConverters.md
+    k4marlinwrapper/doc/starterkit/k4MarlinWrapperCLIC/howtoMultithread.md
+    k4marlinwrapper/doc/starterkit/k4MarlinWrapperCLIC/CEDViaWrapper.md
+    k4simdelphes/doc/starterkit/k4SimDelphes/Readme.md
 ```

--- a/tutorials/example.md
+++ b/tutorials/example.md
@@ -1,0 +1,3 @@
+# Example
+
+Lorum ipsum and all the rest


### PR DESCRIPTION
BEGINRELEASENOTES
- Add a tutorial section to the page.
- Move existing starterkit documentation into the tutorials section

ENDRELEASENOTES

@jmcarcell @andresailer @gaede as discussed I added a tutorial section to the page. Currently there is an empty "example" tutorial just to demonstrate the layout in the end.
This looks like this in the current page:
![image](https://github.com/key4hep/key4hep-doc/assets/16774861/5b28ad92-1f60-458b-9828-86931df1909c)

I will start to add the converter tutorial to this in a separate PR. I think we could potentially merge this first (or at least everyone can start from here). For adding a new tutorial you simply need to add the markdown or rst file into the `eval_rst` block in the `README.md`.