### PR TITLE
Add a how-to / instructions section and populate it with existing content

### DIFF
--- a/.github/scripts/fetch_external_sources.sh
+++ b/.github/scripts/fetch_external_sources.sh
@@ -27,7 +27,7 @@ fetch_for_file() {
 
   while read -r line; do
     # Check if line is non-empty and ends on .md
-    if [ -n "${line}" ] && [[ "${line}" == *.md ]]; then
+    if [ -n "${line}" ] && [[ "${line}" == *.md ]] || [[ "${line}" == *.png ]]; then
       # If the file exists do nothing, otherwise pull it in from github
       local file_to_fetch=${file_dir}/${line}
       if ! ls "${file_to_fetch}" > /dev/null 2>&1; then
@@ -56,3 +56,4 @@ fetch_for_file() {
 
 fetch_for_file README.md
 fetch_for_file tutorials/README.md
+fetch_for_file how-tos/README.md

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ build
 # external repositories
 k4marlinwrapper/
 k4simdelphes/
+key4hep-tutorials
+how-tos

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
     :caption: Contents:
 
     setup-and-getting-started/README.md
+    how-tos/README.md
     tutorials/README.md
     developing-key4hep-software/README.md
     spack-build-instructions-for-librarians/README.md

--- a/how-tos/README.md
+++ b/how-tos/README.md
@@ -1,0 +1,25 @@
+# Key4hep How-Tos and Instructions
+
+This page contains a few brief How-Tos and Instructions on how to achieve
+certain things within the Key4hep software stack. They are mainly aimed at
+Key4hep users and are mostly designed to be reference material, rather than
+[tutorials](https://key4hep.github.io/key4hep-doc/tutorials/README.html).
+
+```eval_rst
+.. toctree::
+   :caption: Contents
+   :maxdepth: 1
+
+   key4hep-tutorials/edm4hep_analysis/edm4hep_api_intro.md
+   k4fwcore/doc/PodioInputOutput.md
+```
+
+<!-- List of image files to also fetch
+key4hep-tutorials/edm4hep_analysis/images/browser_edm4hep_expanded.png
+key4hep-tutorials/edm4hep_analysis/images/doxygen_class_list.png
+key4hep-tutorials/edm4hep_analysis/images/doxygen_reco_particle.png
+key4hep-tutorials/edm4hep_analysis/images/doxygen_type_table.png
+key4hep-tutorials/edm4hep_analysis/images/edm4hep_branches_1.png
+key4hep-tutorials/edm4hep_analysis/images/edm4hep_browse_relations_1.png
+key4hep-tutorials/edm4hep_analysis/images/edm4hep_doxygen.png
+-->

--- a/how-tos/README.md
+++ b/how-tos/README.md
@@ -12,6 +12,7 @@ Key4hep users and are mostly designed to be reference material, rather than
 
    key4hep-tutorials/edm4hep_analysis/edm4hep_api_intro.md
    k4fwcore/doc/PodioInputOutput.md
+   k4marlinwrapper/doc/MarlinWrapperIntroduction.md
 ```
 
 <!-- List of image files to also fetch
@@ -22,4 +23,5 @@ key4hep-tutorials/edm4hep_analysis/images/doxygen_type_table.png
 key4hep-tutorials/edm4hep_analysis/images/edm4hep_branches_1.png
 key4hep-tutorials/edm4hep_analysis/images/edm4hep_browse_relations_1.png
 key4hep-tutorials/edm4hep_analysis/images/edm4hep_doxygen.png
+k4marlinwrapper/doc/marlin_wrapper_tools.png
 -->

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -2,7 +2,9 @@
 
 This page contains several tutorials for working in a Key4hep software stack. We
 try to design and set them up in a way that they can be done at any time but we
-present them at hands-on tutorial sessions as well.
+present them at hands-on tutorial sessions as well. This is an incomplete list
+of all available tutorials, which you can find in the
+[`key4hep-tutorials`](https://github.com/key4hep/key4hep-tutorials) repository.
 
 **If you are following these tutorials and run into an issue please let us know
 by [opening an issue](https://github.com/key4hep/key4hep-doc/issues/new/choose)

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -16,7 +16,7 @@ here.
     :caption: Exercises
 
     k4marlinwrapper/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
-    k4marlinwrapper/doc/MarlinWrapperIntroduction.md
+    key4hep-tutorials/gaudi_ild_reco/README.md
     k4marlinwrapper/doc/starterkit/k4MarlinWrapperCLIC/howtoMultithread.md
     k4marlinwrapper/doc/starterkit/k4MarlinWrapperCLIC/CEDViaWrapper.md
     k4simdelphes/doc/starterkit/k4SimDelphes/Readme.md

--- a/tutorials/example.md
+++ b/tutorials/example.md
@@ -1,3 +1,0 @@
-# Example
-
-Lorum ipsum and all the rest


### PR DESCRIPTION
BEGINRELEASENOTES
- Add a *How-To and Instructions* section and populate it with existing content
  - EDM4hep intro from `key4hep-tutorials`
  - Podio In-/Output from k4FWCore
- Add the tutorial for running sim / reco with ILD 

ENDRELEASENOTES
