### PR TITLE
Fix the path to the new converter documentation

### DIFF
--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -15,7 +15,7 @@ here.
 .. toctree::
     :caption: Exercises
 
-    k4marlinwrapper/doc/starterkit/k4MarlinWrapperCLIC/Readme.md
+    k4marlinwrapper/doc/MarlinWrapperIntroduction.md
     k4marlinwrapper/doc/starterkit/k4MarlinWrapperCLIC/edmConverters.md
     k4marlinwrapper/doc/starterkit/k4MarlinWrapperCLIC/howtoMultithread.md
     k4marlinwrapper/doc/starterkit/k4MarlinWrapperCLIC/CEDViaWrapper.md


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix the path to the new converter documentation in k4MarlinWrapper, needed after https://github.com/key4hep/k4MarlinWrapper/pull/149

ENDRELEASENOTES