### PR TITLE
Add LCIO to EDM4hep conversion to how-to section

### DIFF
--- a/how-tos/README.md
+++ b/how-tos/README.md
@@ -13,6 +13,7 @@ Key4hep users and are mostly designed to be reference material, rather than
    key4hep-tutorials/edm4hep_analysis/edm4hep_api_intro.md
    k4fwcore/doc/PodioInputOutput.md
    k4marlinwrapper/doc/MarlinWrapperIntroduction.md
+   k4edm4hep2lcioconv/doc/LCIO2EDM4hep.md
 ```
 
 <!-- List of image files to also fetch


### PR DESCRIPTION
BEGINRELEASENOTES
- Add the existing LCIO to EDM4hep conversion documentation to how-to section.

ENDRELEASENOTES
