### PR TITLE
Make link to key4hep-tutorials repo more apparent

### DIFF
--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -4,7 +4,7 @@ This page contains several tutorials for working in a Key4hep software stack. We
 try to design and set them up in a way that they can be done at any time but we
 present them at hands-on tutorial sessions as well. This is an incomplete list
 of all available tutorials, which you can find in the
-[`key4hep-tutorials`](https://github.com/key4hep/key4hep-tutorials) repository.
+[key4hep-tutorials](https://github.com/key4hep/key4hep-tutorials) repository.
 
 **If you are following these tutorials and run into an issue please let us know
 by [opening an issue](https://github.com/key4hep/key4hep-doc/issues/new/choose)


### PR DESCRIPTION
BEGINRELEASENOTES
- Make link to key4hep-tutorials repo more apparent

ENDRELEASENOTES
