### PR TITLE
Update the getting started page, contributing and license

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,53 +1,32 @@
 # Contributing
 
-[starterkit-lessons][repo] is an open source project, and we welcome contributions of all kinds:
+Key4hep is an open source project, and we welcome contributions of all kinds:
 
-* New lessons;
-* Fixes to existing material;
-* Bug reports; and
-* Reviews of proposed changes.
+* New lessons
+* Fixes to existing material
+* Bug reports
+* Reviews of proposed changes
 
-By contributing, you are agreeing that we may redistribute your work under [these licenses][license].
-You also agree to abide by our [contributor code of conduct][conduct].
+By contributing, you are agreeing that we may redistribute your work under
+[these licenses][license]. You also agree to abide by our [contributor code of
+conduct][conduct].
 
 ## Getting Started
 
 1.  We use the [fork and pull][gh-fork-pull] model to manage changes.
     More information about [forking a repository][gh-fork] and [making a Pull Request][gh-pull].
 
-2.  To build the lessons please install the [dependencies](#dependencies).
+2.  You should branch from and submit pull requests against the `main` branch
+    (in some repositories it may still be `master` but this will change in the
+    future to `main`).
 
-2.  For our lessons, you should branch from and submit pull requests against the `master` branch.
-
-3.  When editing lesson pages, you need only commit changes to the Markdown source files.
-
-4.  If you're looking for things to work on, please see [the list of issues for this repository][issues].
-    Comments on issues and reviews of pull requests are equally welcome.
-
-## Dependencies
-
-To build the lessons locally, install the following:
-
-1. [starterkit-ci](https://pypi.org/project/starterkit-ci/)
-
-Then build the pages:
-
-```shell
-$ starterkit_ci build --allow-warnings
-$ starterkit_ci check --allow-warnings
-```
-
-and start a web server to host them:
-
-```shell
-$ cd build
-$ python -m http.server 8000
-```
-You can see your local version by using a web-browser to navigate to `http://localhost:8000` or wherever it says it's serving the book.
+3.  If you're looking for things to work on, feel free to get in touch with the
+    Key4hep team at key4hep dash sw @ cern dot ch. You can also have a look at
+    the [the list of issues for this repository][issues]. Comments on issues and
+    reviews of pull requests are equally welcome.
 
 [conduct]: CONDUCT.md
-[repo]: https://github.com/lhcb/starterkit-lessons
-[issues]: https://github.com/lhcb/starterkit-lessons/issues
+[issues]: https://github.com/search?o=desc&q=org%3Akey4hep&s=created&type=Issues
 [license]: LICENSE.md
 [pro-git-chapter]: http://git-scm.com/book/en/v2/GitHub-Contributing-to-a-Project
 [gh-fork]: https://help.github.com/en/articles/fork-a-repo

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,64 +1,10 @@
-# Instructional Material
-
-All instructional material is made available under the [Creative Commons 
-Attribution license][cc-by-human]. The following is a human-readable summary of 
-(and not a substitute for) the [full legal text of the CC BY 4.0 
-license][cc-by-legal].
-
-You are free to:
-
-* to **Share** --- copy and redistribute the material in any medium or format
-* to **Adapt** --- remix, transform, and build upon the material for any 
-  purpose, even commercially.
-
-The licensor cannot revoke these freedoms as long as you follow the license 
-terms.
-
-Under the following terms:
-
-* **Attribution** --- You must give appropriate credit, provide a [link to the 
-  license][cc-by-human], and indicate if changes were made. You may do so in 
-  any reasonable manner, but not in any way that suggests the licensor endorses 
-  you or your use.
-
-* **No additional restrictions** --- You may not apply legal terms or 
-  technological measures that legally restrict others from doing anything the 
-  license permits.
-
-Notices:
-
-* You do not have to comply with the license for elements of the material in 
-  the public domain or where your use is permitted by an applicable exception 
-  or limitation.
-* No warranties are given. The license may not give you all of the permissions 
-  necessary for your intended use. For example, other rights such as publicity, 
-  privacy, or moral rights may limit how you use the material.
-
 # Software
 
-Except where otherwise noted, the example programs and other software provided 
-by Software Carpentry are made available under the [OSI][osi]-approved [MIT 
-license][mit-license].
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of 
-this software and associated documentation files (the "Software"), to deal in 
-the Software without restriction, including without limitation the rights to 
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies 
-of the Software, and to permit persons to whom the Software is furnished to do 
-so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all 
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
-SOFTWARE.
+Except where otherwise noted, the example programs and other software provided
+by Software Carpentry are made available under the [OSI][osi]-approved [Apache
+2.0][license].
 
 [cc-by-human]: https://creativecommons.org/licenses/by/4.0/
 [cc-by-legal]: https://creativecommons.org/licenses/by/4.0/legalcode
-[mit-license]: https://opensource.org/licenses/mit-license.html
+[license]: https://opensource.org/license/apache-2-0/
 [osi]: https://opensource.org

--- a/setup-and-getting-started/README.md
+++ b/setup-and-getting-started/README.md
@@ -14,7 +14,7 @@ source /cvmfs/sw.hsf.org/key4hep/setup.sh
 ```
 
 In addition, nightly builds for CentOS 7, AlmaLinux 9 and Ubuntu 22.04 with the
-latest version of many packages are available:
+latest version of most of the packages are available:
 
 ```bash
 source /cvmfs/sw-nightlies.hsf.org/key4hep/setup.sh
@@ -25,63 +25,3 @@ without warning. However, after sourcing the script some information will be
 displayed with instructions on how to reproduce the current environment. Nightly
 builds are intended for development and testing and they will be deleted after
 some time from `/cvmfs`.
-
-### Using Virtual Machines or Docker containers
-
-The instructions above should work on any virtual machine or Docker container
-with `cvmfs` available. We give in the following one example for each of the two
-cases.
-
-#### CernVM Virtual Appliance
-
-The CernVM project provides a convenient tool to start VMs, [cernvm-launch](https://cernvm.cern.ch/portal/launch), and a [public repository](https://github.com/cernvm/public-contexts) of contexts to be used with `cernvm-launch` to configure the VM at your needs. A context dedicated to Key4hep is available in the repository. The [cernvm-launch](https://cernvm.cern.ch/portal/launch) works with [VirtualBox](https://www.virtualbox.org/), virtualization manager available for free for all platforms.
-
-To create and use a CernVM virtual machine for Key4hep please follow the following steps:
-
-   * Make sure [VirtualBox](https://www.virtualbox.org/) is installed (details installing instructions from the product web page).
-   * Download the `cernvm-launch` binary for your platform either from the [dedicated download page](https://ecsft.cern.ch/dist/cernvm/launch/bin/) or from the following links:
-      * [Linux](https://fccsw.web.cern.ch/fccsw/utils/vm/cernvm/launch/linux/cernvm-launch)
-      * [Mac](https://fccsw.web.cern.ch/fccsw/utils/vm/cernvm/launch/mac/cernvm-launch)
-
-     Make sure is visible in your $PATH.
-   * Get the [k4h-dev.context](https://raw.githubusercontent.com/cernvm/public-contexts/master/k4h-dev.context) (use wget or curl)
-
-Once you have all this you can create the VM with this command:
-```
-$ cernvm-launch create --name k4h-dev --cpus 4 --memory 8000 --disk 20000 k4h-dev.context
-```
-You an choose how many CPU cores to use, the memory and the disk space. Good rules of thumb are to use half the cores of your machine, at least 2 GB memory per core, and enough disk for your job. The above command should oepn a window with VirtualBox and produce on the screen an output like this
-```
-Using user data file: k4h-dev.context
-Parameters used for the machine creation:
-	name: k4h-dev
-	cpus: 4
-	memory: 8000
-	disk: 20000
-	cernvmVersion: 2019.06-1
-	sharedFolder: /mnt/shared/k4h-dev-vs
-```
-You see in partcular that your `$HOME` area is shared with the VM, so you can exchange files between the VM and the host machine very conveniently.
-From now on you can either work in the VirtualBox window or ssh to the machine with
-```
-cernvm-launch ssh k4h-dev
-```
-In either case you need a user name and password, which by default are `k4huser` and `pass`; these can be changed in the `k4h-dev.context` file.
-
-To enable graphics you need to find out the port on which the VM responds and use `ssh -Y -P <port> fccuser@localhost`. For example
-```
-$ cernvm-launch list
-k4h-dev`:	CVM: 2019.06-1	port: 36998
-...
-$ ssh -Y -P 36998 k4huser@localhost
-The authenticity of host '[localhost]:36998 ([127.0.0.1]:36998)' can't be established.
-ECDSA key fingerprint is SHA256:JXjpOzSu7vIwgEDxc8s/fdDJv4gQs2SUjnbMnEZsaYI.
-Are you sure you want to continue connecting (yes/no)? yes
-Warning: Permanently added '[localhost]:36998' (ECDSA) to the list of known hosts.
-k4huser@localhost's password:
-[k4huser@localhost ~]$
-```
-(you can safely ignore warnings about setting LC_CTYPE).
-Graphics should of course work well if you choose to work in the VirtualBox window.
-
-The `cernvm-launch` also supports listing, stopping, starting virtual machines. Please run `cernvm-launch -h` for all the available options.


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove the information related to CernVM in the getting started page
- Update the contribution page with information about key4hep
- Update the license page with Apache v2.0

ENDRELEASENOTES