### PR TITLE
Remove the starterkit-ci dependency

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -1,44 +1,45 @@
 # You should normally never do wildcard imports
 # Here it is useful to allow the configuration to be maintained elsewhere
-from starterkit_ci.sphinx_config import *  # NOQA
+# from starterkit_ci.sphinx_config import *  # NOQA
 
-project = 'Key4hep'
-copyright = '2020, Key4hep'
-author = 'Key4hep'
-html_logo = 'starterkit.png'
+project = "Key4hep"
+copyright = "2020, Key4hep"
+author = "Key4hep"
+# html_logo = "starterkit.png"
 
-exclude_patterns += [
-    'archive',
-    'README.md',
+exclude_patterns = [
+    "_build",
+    "Thumbs.db",
+    ".DS_Store" "archive",
+    "README.md",
 ]
 
 html_theme = "sphinx_rtd_theme"
 
 html_context = {
-    'display_github': True,
-    'github_user': 'key4hep',
-    'github_repo': 'key4hep-doc',
-    'github_version': 'main',
-    'conf_py_path': '/',
+    "display_github": True,
+    "github_user": "key4hep",
+    "github_repo": "key4hep-doc",
+    "github_version": "main",
+    "conf_py_path": "/",
 }
 
 extensions = [
-    'sphinx_copybutton',
-    'sphinx_markdown_tables',
+    "sphinx_copybutton",
+    "sphinx_markdown_tables",
     "sphinx_design",
-    'myst_parser',
+    "myst_parser",
 ]
 
 source_suffix = {
-    '.md': 'markdown',
+    ".md": "markdown",
 }
 
-#html_static_path += [
+# html_static_path += [
 #    f'_static',
-#]
+# ]
 
-linkcheck_ignore += [
-]
+linkcheck_ignore = []
 
 myst_heading_anchors = 3
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 sphinx==7.2.6
 myst-parser==2.0.0
-starterkit-ci==0.0.12
 sphinx-copybutton==0.5.2
 sphinx-markdown-tables==0.0.17
 notedown==1.5.1


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove the dependency from `starterkit-ci` since we don't really use much of it.

ENDRELEASENOTES
