### PR TITLE
Make the build workflow manually triggerable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: build
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:


### PR DESCRIPTION
BEGINRELEASENOTES
- Add `workflow_dispatch` to the triggers for the `build` workflow to make it manually triggerable

ENDRELEASENOTES
