### PR TITLE
Ignore TWiki that requires login from linkcheck

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -39,7 +39,9 @@ source_suffix = {
 #    f'_static',
 # ]
 
-linkcheck_ignore = []
+linkcheck_ignore = [
+    r"https://twiki.cern.ch/twiki/bin/view",  # TWikis might need login
+]
 
 myst_heading_anchors = 3
 

--- a/developing-key4hep-software/WritingAlgorithms.md
+++ b/developing-key4hep-software/WritingAlgorithms.md
@@ -296,7 +296,7 @@ loading, user can start running of the steering by typing `continue` into the
 GDB console. To interrupt running of the Gaudi steering use `CTRL+C`.
 
 More details how to run GDB with Gaudi can be found in
-[LHCb Code Analysis Tools](https://twiki.cern.ch/twiki/bin/view/LHCb/CodeAnalysisTools#Debugging_gaudirun_py_on_Linux_w).
+[LHCb Code Analysis Tools](https://twiki.cern.ch/twiki/bin/view/LHCb/CodeAnalysisTools#Debugging_gaudirun_py_on_Linux_w) (requires a CERN account to view).
 
 ## Avoiding const in `operator()`
 There is a way of working around `operator()` being const and that is by adding


### PR DESCRIPTION
BEGINRELEASENOTES
- Ignore links to the CERN TWiki in the link check as they might require login

ENDRELEASENOTES
