### PR TITLE
Fix link to spack documentation

### DIFF
--- a/spack-build-instructions-for-librarians/spack-advanced.md
+++ b/spack-build-instructions-for-librarians/spack-advanced.md
@@ -113,7 +113,7 @@ in `$HOME/.spack/linux/packages.yaml`
 ## Bundle Packages and Environments
 
 Right now, key4hep is installed via a `BundlePackage`, that depends on all other relevant packages.
-An alternative would be to use [spack environments](https://spack-tutorial.readthedocs.io/en/latest/tutorial_environments.html#creating-and-activating-environments). This alternative is still under investigation.
+An alternative would be to use [spack environments](https://spack-tutorial.readthedocs.io/en/latest/tutorial_environments.html). This alternative is still under investigation.
 
 
 ## Setting Up Runtime Environments 


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix link to spack documentation that has gone out of sync due to https://github.com/spack/spack-tutorial/pull/355
ENDRELEASENOTES
