### PR TITLE
Don't check opensource.org links in github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: 3.11
+        python-version: 3.12
     - name: Install Requirements
       run: |
         pip install --upgrade pip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,20 +12,6 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: 3.12
-    - name: Figure out IP
-      run: |
-        curl https://ipinfo.io
-    - name: Try curl to get to opensource.org
-      run: |
-        curl -I https://opensource.org/ \
-          -v \
-          --http1.1 \
-          -H "Host: opensource.org" \
-          -H "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36" \
-          -H "Accept-Encoding: gzip, deflate" \
-          -H "Accept: */*" \
-          -H "Connection: keep-alive"
-
     - name: Install Requirements
       run: |
         pip install --upgrade pip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ jobs:
     - name: Try curl to get to opensource.org
       run: |
         curl -I https://opensource.org/ \
+          -v \
           --http1.1 \
           -H "User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:100.0) Gecko/20100101 Firefox/100.0 Sphinx/7.2.6" \
           -H "Accept-Encoding: gzip, deflate" \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,13 +12,16 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: 3.12
+    - name: Figure out IP
+      run: |
+        curl https://ipinfo.io
     - name: Try curl to get to opensource.org
       run: |
         curl -I https://opensource.org/ \
           -v \
           --http1.1 \
           -H "Host: opensource.org" \
-          -H "User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:100.0) Gecko/20100101 Firefox/100.0 Sphinx/7.2.6" \
+          -H "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36" \
           -H "Accept-Encoding: gzip, deflate" \
           -H "Accept: */*" \
           -H "Connection: keep-alive"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,15 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: 3.12
+    - name: Try curl to get to opensource.org
+      run: |
+        curl -I https://opensource.org/ \
+          --http1.1 \
+          -H "User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:100.0) Gecko/20100101 Firefox/100.0 Sphinx/7.2.6" \
+          -H "Accept-Encoding: gzip, deflate" \
+          -H "Accept: */*" \
+          -H "Connection: keep-alive"
+
     - name: Install Requirements
       run: |
         pip install --upgrade pip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ jobs:
         curl -I https://opensource.org/ \
           -v \
           --http1.1 \
+          -H "Host: opensource.org" \
           -H "User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:100.0) Gecko/20100101 Firefox/100.0 Sphinx/7.2.6" \
           -H "Accept-Encoding: gzip, deflate" \
           -H "Accept: */*" \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: 3.11
+        python-version: 3.12
     - name: Install Requirements
       run: |
         pip install --upgrade pip

--- a/conf.py
+++ b/conf.py
@@ -43,11 +43,7 @@ linkcheck_ignore = [
     r"https://twiki.cern.ch/twiki/bin/view",  # TWikis might need login
 ]
 
-linkcheck_request_headers = {
-    r"https://opensource.org": {
-        "User-Agent": "Mozilla/5.0 (X11; Ubuntu; Linux i686; rv:24.0) Gecko/20100101 Firefox/24.0"
-    }
-}
+# linkcheck_request_headers = {r"https://opensource.org": {"User-Agent": ""}}
 
 myst_heading_anchors = 3
 

--- a/conf.py
+++ b/conf.py
@@ -2,9 +2,10 @@
 # Here it is useful to allow the configuration to be maintained elsewhere
 # from starterkit_ci.sphinx_config import *  # NOQA
 
-import http.client
+import os
 
-# http.client.HTTPConnection.debuglevel = 1
+IN_GITHUB_ACTIONS_CI = os.environ.get("GITHUB_ACTIONS", False)
+
 
 project = "Key4hep"
 copyright = "2020, Key4hep"
@@ -39,18 +40,13 @@ source_suffix = {
     ".md": "markdown",
 }
 
-# html_static_path += [
-#    f'_static',
-# ]
-
-
-# linkcheck_request_headers = {
-#     "https://opensource.org": {"User-Agent": "Python-urllib/3.12"}
-# }
-
 linkcheck_ignore = [
     r"https://twiki.cern.ch/twiki/bin/view",  # TWikis might need login
 ]
+if IN_GITHUB_ACTIONS_CI:
+    linkcheck_ignore.append(
+        r"https://opensource.org",  # cloudflare blocks requests from github actions
+    )
 
 
 myst_heading_anchors = 3

--- a/conf.py
+++ b/conf.py
@@ -2,6 +2,10 @@
 # Here it is useful to allow the configuration to be maintained elsewhere
 # from starterkit_ci.sphinx_config import *  # NOQA
 
+import http.client
+
+http.client.HTTPConnection.debuglevel = 1
+
 project = "Key4hep"
 copyright = "2020, Key4hep"
 author = "Key4hep"
@@ -39,11 +43,15 @@ source_suffix = {
 #    f'_static',
 # ]
 
+
+# linkcheck_request_headers = {
+#     "https://opensource.org": {"User-Agent": "Python-urllib/3.12"}
+# }
+
 linkcheck_ignore = [
     r"https://twiki.cern.ch/twiki/bin/view",  # TWikis might need login
 ]
 
-# linkcheck_request_headers = {r"https://opensource.org": {"User-Agent": ""}}
 
 myst_heading_anchors = 3
 

--- a/conf.py
+++ b/conf.py
@@ -43,6 +43,12 @@ linkcheck_ignore = [
     r"https://twiki.cern.ch/twiki/bin/view",  # TWikis might need login
 ]
 
+linkcheck_request_headers = {
+    "https://opensource.org": {
+        "User-Agent": "Mozilla/5.0 (X11; Ubuntu; Linux i686; rv:24.0) Gecko/20100101 Firefox/24.0"
+    }
+}
+
 myst_heading_anchors = 3
 
 myst_enable_extensions = ["colon_fence"]

--- a/conf.py
+++ b/conf.py
@@ -44,7 +44,7 @@ linkcheck_ignore = [
 ]
 
 linkcheck_request_headers = {
-    "https://opensource.org": {
+    r"https://opensource.org": {
         "User-Agent": "Mozilla/5.0 (X11; Ubuntu; Linux i686; rv:24.0) Gecko/20100101 Firefox/24.0"
     }
 }

--- a/conf.py
+++ b/conf.py
@@ -4,7 +4,7 @@
 
 import http.client
 
-http.client.HTTPConnection.debuglevel = 1
+# http.client.HTTPConnection.debuglevel = 1
 
 project = "Key4hep"
 copyright = "2020, Key4hep"


### PR DESCRIPTION
BEGINRELEASENOTES
- Don't check opensource.org via linkcheck when running in github actions since cloudflare is apparently detecting that and blocking us from doing so
- Switch to python 3.12 for running the documentation building

ENDRELEASENOTES
