### PR TITLE
fix rendering logo8 images

### DIFF
--- a/docs/call-for-logos/README.md
+++ b/docs/call-for-logos/README.md
@@ -32,7 +32,12 @@ Logo 7
 
 Logo 8
 
-<picture>
-  <img src="key4hep_logo8.svg"         width="20%" style="margin-right: 100px;" />
-  <img src="key4hep_logo8_outline.svg" width="20%"/>
-</picture>
+```{image} key4hep_logo8.svg
+:width: 20%
+:align: left
+```
+
+```{image} key4hep_logo8_outline.svg
+:width: 20%
+:align: center
+```


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix rendering logo8

ENDRELEASENOTES
Follow-up to #98
For whatever reason sphinx/mys-parser fails to understand multiple images in pictures and produces invalid paths.
I guess the intent was to have two pictures on the same line with some margin. Here is a workaround using myst-parser

![image](https://github.com/user-attachments/assets/341a099e-70fb-41b2-b480-ff23739b6c5c)

