### PR TITLE
Add the FCC SW forum as an external link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -36,6 +36,7 @@
     :caption: External links
 
     FCC software  <https://cern.ch/fccsw>
+    FCC SW forum <https://fccsw-forum.web.cern.ch/>
     CLIC software <https://twiki.cern.ch/twiki/bin/view/CLIC/CLICSoftwareComputing>
     ILC software <https://ilcsoft.desy.de/portal>
     CEPC software <http://cepcsoft.ihep.ac.cn/>


### PR DESCRIPTION
As discussed between @tmadlener and @BrieucF and @davidlange6

(edit: tagged the correct Brieuc and added David)