### PR TITLE
Revert "Remove a reference to PodioInputOutput.md that doesn't exist anymore"

### DIFF
--- a/docs/how-tos/README.md
+++ b/docs/how-tos/README.md
@@ -11,6 +11,7 @@ Key4hep users and are mostly designed to be reference material, rather than
    :maxdepth: 1
 
    key4hep-tutorials/edm4hep_analysis/edm4hep_api_intro.md
+   k4fwcore/doc/PodioInputOutput.md
    k4fwcore/doc/k4run-args.md
    k4fwcore/doc/algorithmTiming.md
    k4marlinwrapper/doc/MarlinWrapperIntroduction.md


### PR DESCRIPTION
Reverts key4hep/key4hep-doc#146