### PR TITLE
Fix action warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,10 +56,10 @@ jobs:
     needs: [generate-alg-overview, generate-proc-overview]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         ref: ${{ inputs.ref }}
-    - uses: actions/setup-python@v6
+    - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: 3.12
         cache: pip
@@ -69,13 +69,13 @@ jobs:
           pip install -r requirements.txt
     - name: Download algorithm overview
       if: ${{ inputs.generate-overviews }}
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: docs-algorithm-overview.md
         path: docs/
     - name: Download processor overview
       if: ${{ inputs.generate-overviews }}
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: docs-processor-overview.md
         path: docs/
@@ -97,7 +97,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         sphinx-build -b linkcheck docs linkcheck
-    - uses: actions/upload-pages-artifact@v4
+    - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
       if: ${{ inputs.upload-artifact }}
       with:
         path: build/html

--- a/.github/workflows/generate_overview.yml
+++ b/.github/workflows/generate_overview.yml
@@ -35,7 +35,7 @@ jobs:
   generate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.ref }}
       - name: Collect github repositories
@@ -45,8 +45,8 @@ jobs:
           gh search repos --owner=key4hep --archived=false --visibility=public --json name,url --limit 100 > key4hep_repositories.json
           gh search repos --owner=hep-fcc --archived=false --visibility=public --json name,url --limit 100 > hep-fcc_repositories.json
           gh search repos --owner=ilcsoft --archived=false --visibility=public --json name,url --limit 100 > ilcsoft_repositories.json
-      - uses: cvmfs-contrib/github-action-cvmfs@v5
-      - uses: aidasoft/run-lcg-view@v5
+      - uses: cvmfs-contrib/github-action-cvmfs@10197e000cc0add8e54ac4fb73d3ed44e2de72b4 # v5.5
+      - uses: aidasoft/run-lcg-view@b4da52e1c5ccb70a60ad4e7216de0a90664d5849 # v6.0.2
         with:
           container: ubuntu2404
           view-path: /cvmfs/sw-nightlies.hsf.org/key4hep
@@ -63,7 +63,7 @@ jobs:
       - name: Compute artifact name
         id: artifact-name
         run: echo "name=$(echo '${{ inputs.output }}' | tr '/' '-')" >> "$GITHUB_OUTPUT"
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ steps.artifact-name.outputs.name }}
           path: ${{ inputs.output }}

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -21,7 +21,7 @@ jobs:
       pr-number: ${{ github.event.number }}
 
   linkcheck:
-    if: contains(['opened', 'reopened', 'synchronize'], ${{ github.event.action }})
+    if: contains(fromJSON('["opened", "reopened", "synchronize"]'), github.event.action)
     uses: ./.github/workflows/build.yml
     with:
       ref: ${{ github.event.pull_request.head.sha }}
@@ -55,7 +55,7 @@ jobs:
 
       - name: Deploy Preview
         uses: rossjrw/pr-preview-action@v1.6.2
-        if: contains(['opened', 'reopened', 'synchronize'], ${{ github.event.action }})
+        if: contains(fromJSON('["opened", "reopened", "synchronize"]'), github.event.action)
         with:
           source-dir: pr-preview-unpacked
           preview-branch: gh-pages

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -38,11 +38,11 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - uses: actions/download-artifact@v6
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: github-pages
           path: doc_artifact
@@ -54,7 +54,7 @@ jobs:
           rm -r doc_artifact
 
       - name: Deploy Preview
-        uses: rossjrw/pr-preview-action@v1.6.2
+        uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 # v1.8.1
         if: contains(fromJSON('["opened", "reopened", "synchronize"]'), github.event.action)
         with:
           source-dir: pr-preview-unpacked
@@ -64,7 +64,7 @@ jobs:
           action: auto
 
       - name: Remove Preview
-        uses: rossjrw/pr-preview-action@v1.6.2
+        uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 # v1.8.1
         if: github.event.action == 'closed' && !github.event.pull_request.merged
         with:
           source-dir: pr-preview-unpacked

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,10 +26,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         ref: gh-pages
-    - uses: actions/download-artifact@v6
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: github-pages
         path: doc_artifact


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix broken linkcheck and preview workflows
- Update all actions to latest versions and pin by commit sha rather than by tag to avoid vulnerabilities to supply chain attacks

ENDRELEASENOTES
